### PR TITLE
Use outline to indicate potentially expandable click targets

### DIFF
--- a/style.css
+++ b/style.css
@@ -40,3 +40,6 @@ li {
 	margin-bottom: 2px;
 	margin-top: 2px;
 }
+#tree li:hover {
+	outline: thin dotted grey;
+}


### PR DESCRIPTION
I always click in space that seems to be blank, but is actually part of an expandable \<li>. This adds a visual indication of DOM reality.

![screen](https://user-images.githubusercontent.com/1199584/55239709-a2269200-520d-11e9-95da-635801f1e27b.png)