### PR TITLE
Support modern test262.zip files

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ Prior to this, it hadn't been possible to run an up-to-date version of test262 i
 
 You can either provide a local .zip of the repo (with or without .git/), or click 'Remote' to load the one hosted in this repository.
 
-The hosted copy was last updated on 05 November, 2018.
+The hosted copy was last updated on 11 March, 2025.
 
 A version allowing preprocessing of tests, intended for tool authors, is available [here](https://bakkot.github.io/test262-web-runner/transformed.html).
+
+Running this locally using cross origin isolation is possible using `python cross-origin-http.py`.  This allows Shared Array Buffer tests to work as expected.
+

--- a/cross-origin-http.py
+++ b/cross-origin-http.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+import sys
+
+class CustomRequestHandler(SimpleHTTPRequestHandler):
+    def end_headers(self):
+        self.send_header('Cross-Origin-Embedder-Policy', 'require-corp')
+        self.send_header('Cross-Origin-Opener-Policy', 'same-origin')
+        return super(CustomRequestHandler, self).end_headers()
+
+host = sys.argv[1] if len(sys.argv) > 2 else '0.0.0.0'
+port = int(sys.argv[len(sys.argv)-1]) if len(sys.argv) > 1 else 8000
+
+print("Listening on {}:{}".format(host, port))
+print("Connect to http://localhost:{}/ for cross-origin isolation".format(port))
+httpd = HTTPServer((host, port), CustomRequestHandler)
+httpd.serve_forever()

--- a/main.js
+++ b/main.js
@@ -89,7 +89,11 @@ function loadUnit(path) {
   return function(then, error) {
     return function(task) {
       var file = path.reduce(function(acc, name) { return acc.files[name]; }, tree).file;
-      file.async("string").then(function(c) { then(task, c); }, function(e) { error(task); });
+      if (file) {
+        file.async("string").then(function(c) { then(task, c); }, function(e) { error(task); });
+      } else {
+        then();
+      }
     };
   };
 }
@@ -708,6 +712,9 @@ function loadZip(z) {
     var renderPromise = new Promise(function(_resolve, _reject) { resolve = _resolve; reject = _reject; });
     var harnessNames = Object.keys(tree.files.harness.files);
     loadAllUnqueued(harnessNames.map(function(include) { return ['harness', include]; }), function(harnessFiles) {
+      if (!harnessFiles) {
+        resolve();
+      }
       try {
         for (var i = 0; i < harnessNames.length; ++i) {
           harness[harnessNames[i]] = harnessFiles[i];
@@ -778,7 +785,10 @@ window.addEventListener('load', function() {
     loadStatus.style.display = 'inline-block';
     loadZip(file)
       .then(function() { loadStatus.innerHTML = 'Loaded <kbd>' + safeSrc + '</kbd>.'; })
-      .catch(function(e) { loadStatus.textContent = e; })
+      .catch(function(e) {
+        console.log(e)
+        loadStatus.textContent = e;
+      })
       .then(function() { fileEle.value = ''; });
   });
 


### PR DESCRIPTION
I noticed when running this that recent test262 zip files break. The recent addition of the "sm" directory is the cause of the breakage: https://github.com/tc39/test262/tree/main/harness/sm

This should be fixed at some point, but for now we can just ignore paths that result in no valid tests.