### PR TITLE
Split "load from URL" functionality into latest (via CORS proxy) vs. current (committed snapshot)

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
 			Load a .zip of <a href="https://github.com/tc39/test262.git">the Test262 repository</a> (e.g. <a href="https://api.github.com/repos/tc39/test262/zipball">this</a>):
 			<input type="button" class="btn btn-default btn-sm" id="loadLocal" value="Local">
 			<input type="button" class="btn btn-default btn-sm" id="loadCurrent" value="Current (via proxy)">
-			<input type="button" class="btn btn-default btn-sm" id="loadSnapshot" value="Latest snapshot">
+			<input type="button" class="btn btn-default btn-sm" id="loadSnapshot" value="Latest snapshot (2018-11-05)">
 			<div id="loadStatus" style="display: none;">Loading... <span id="loadFraction"></span></div>
 		</div>
 		<div id="tree"></div>

--- a/index.html
+++ b/index.html
@@ -22,7 +22,8 @@
 		<div id="buttons">
 			Load a .zip of <a href="https://github.com/tc39/test262.git">the Test262 repository</a> (e.g. <a href="https://api.github.com/repos/tc39/test262/zipball">this</a>):
 			<input type="button" class="btn btn-default btn-sm" id="loadLocal" value="Local">
-			<input type="button" class="btn btn-default btn-sm" id="loadGithub" value="Remote">
+			<input type="button" class="btn btn-default btn-sm" id="loadCurrent" value="Current (via proxy)">
+			<input type="button" class="btn btn-default btn-sm" id="loadSnapshot" value="Latest snapshot">
 			<div id="loadStatus" style="display: none;">Loading... <span id="loadFraction"></span></div>
 		</div>
 		<div id="tree"></div>

--- a/main.js
+++ b/main.js
@@ -1,7 +1,11 @@
 'use strict';
 
-// var zipballUrl = 'https://api.github.com/repos/tc39/test262/zipball'; // this would be nice, but while the API claims to support CORS, it doesn't for this particular endpoint
-var zipballUrl = 'tc39-test262-69c1efd.zip';
+// Direct use of the GitHub URL is blocked by CORS:
+// https://github.com/orgs/community/discussions/45446
+// var zipballUrl = 'https://api.github.com/repos/tc39/test262/zipball';
+var zipballUrl = 'https://corsproxy.io/?url=https://api.github.com/repos/tc39/test262/zipball';
+
+var snapshotUrl = 'tc39-test262-69c1efd.zip';
 
 var skippedRegex = /integer-limit/; // todo this should not be here, and should probably be exposed
 
@@ -796,9 +800,16 @@ window.addEventListener('load', function() {
     fileEle.click();
   });
 
-  document.getElementById('loadGithub').addEventListener('click', function() {
-    var src = zipballUrl;
-    var safeSrc = src.replace(/</g, '&lt;');
+  document.getElementById('loadCurrent').addEventListener('click', function() {
+    loadFromUrl(zipballUrl);
+  });
+
+  document.getElementById('loadSnapshot').addEventListener('click', function() {
+    loadFromUrl(snapshotUrl);
+  });
+
+  function loadFromUrl(url) {
+    var safeSrc = url.replace(/</g, '&lt;');
     document.getElementById('tree').textContent = '';
     loadStatus.innerHTML = 'Loading <kbd>' + safeSrc + '</kbd>... <span id="loadFraction"></span>';
     loadStatus.style.display = 'inline-block';
@@ -830,7 +841,7 @@ window.addEventListener('load', function() {
       }
     });
 
-    req.open('GET', zipballUrl);
+    req.open('GET', url);
     req.responseType = 'arraybuffer'; // todo check support
     req.send();
   });

--- a/transformed.html
+++ b/transformed.html
@@ -33,7 +33,8 @@
 			<span id="buttons">
 				Load a .zip of <a href="https://github.com/tc39/test262.git">the Test262 repository</a> (e.g. <a href="https://api.github.com/repos/tc39/test262/zipball">this</a>):
 				<input type="button" class="btn btn-default btn-sm" id="loadLocal" value="Local">
-				<input type="button" class="btn btn-default btn-sm" id="loadGithub" value="Remote">
+				<input type="button" class="btn btn-default btn-sm" id="loadCurrent" value="Current (via proxy)">
+				<input type="button" class="btn btn-default btn-sm" id="loadSnapshot" value="Latest snapshot">
 				<div id="loadStatus" style="display: none;">Loading... <div id="loadFraction"></div></div>
 				<br>
 			</span>


### PR DESCRIPTION
Fixes #18