### PR TITLE
remove proxy option

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,6 @@
 		<div id="buttons">
 			Load a .zip of <a href="https://github.com/tc39/test262.git">the Test262 repository</a> (e.g. <a href="https://api.github.com/repos/tc39/test262/zipball">this</a>):
 			<input type="button" class="btn btn-default btn-sm" id="loadLocal" value="Local">
-			<input type="button" class="btn btn-default btn-sm" id="loadCurrent" value="Current (via proxy)">
 			<input type="button" class="btn btn-default btn-sm" id="loadSnapshot" value="Latest snapshot (REPLACE_THIS)">
 			<div id="loadStatus" style="display: none;">Loading... <span id="loadFraction"></span></div>
 		</div>

--- a/main.js
+++ b/main.js
@@ -3,7 +3,7 @@
 // Direct use of the GitHub URL is blocked by CORS:
 // https://github.com/orgs/community/discussions/45446
 // var zipballUrl = 'https://api.github.com/repos/tc39/test262/zipball';
-var zipballUrl = 'https://cors-anywhere.homely8896.workers.dev/https://api.github.com/repos/tc39/test262/zipball';
+// var zipballUrl = 'https://cors-anywhere.homely8896.workers.dev/https://api.github.com/repos/tc39/test262/zipball';
 
 var snapshotUrl = 'test262.zip';
 
@@ -800,9 +800,9 @@ window.addEventListener('load', function() {
     fileEle.click();
   });
 
-  document.getElementById('loadCurrent').addEventListener('click', function() {
-    loadFromUrl(zipballUrl);
-  });
+  // document.getElementById('loadCurrent').addEventListener('click', function() {
+  //   loadFromUrl(zipballUrl);
+  // });
 
   document.getElementById('loadSnapshot').addEventListener('click', function() {
     loadFromUrl(snapshotUrl);


### PR DESCRIPTION
As of https://github.com/bakkot/test262-web-runner/commit/eb22962cf8024f837517b1dc8817239e8601b2ea we refresh the hosted .zip nightly, which I think is good enough, and I don't want to have to keep finding new proxies (current one is down again) or run one myself.